### PR TITLE
Update the runtime version from 48 to 50, and more

### DIFF
--- a/com.gooseberrydevelopment.pinepods.yml
+++ b/com.gooseberrydevelopment.pinepods.yml
@@ -1,6 +1,6 @@
 id: com.gooseberrydevelopment.pinepods
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 command: app
 finish-args:
@@ -51,3 +51,7 @@ modules:
       - install -Dm644 usr/share/icons/hicolor/256x256@2/apps/app.png /app/share/icons/hicolor/256x256@2/apps/com.gooseberrydevelopment.pinepods.png
       - install -Dm644 usr/share/applications/Pinepods.desktop /app/share/applications/com.gooseberrydevelopment.pinepods.desktop
       - install -Dm644 usr/share/metainfo/com.gooseberrydevelopment.pinepods.metainfo.xml /app/share/metainfo/com.gooseberrydevelopment.pinepods.metainfo.xml
+      # Copy missing license file from the libdbusmenu module
+      - mkdir -p /app/share/licenses/${FLATPAK_ID}/pinepods/
+      - cp /app/share/licenses/${FLATPAK_ID}/libdbusmenu/COPYING-GPL3 /app/share/licenses/${FLATPAK_ID}/pinepods/COPYING
+


### PR DESCRIPTION
- Update the runtime version to 50
- Update shared-modules
- Add missing license file. Fixes: #6

**Please don't forget to test before merging.**